### PR TITLE
Update obs2.py

### DIFF
--- a/src/georinex/obs2.py
+++ b/src/georinex/obs2.py
@@ -457,6 +457,12 @@ def _getSVlist(ln: str, N: int,
                sv: List[str]) -> List[str]:
     """ parse a line of text from RINEX2 SV list"""
     sv.extend([ln[32+i*3:35+i*3] for i in range(N)])
+    
+    # compatibility for early rinex where a space
+    # in SSI position is assumed to be GPS
+    for i, s in enumerate(sv):
+        if s[0] == ' ':
+            sv[i]='G'+s[1:3]
 
     return sv
 


### PR DESCRIPTION
compatibility for early rinex where a space in SSI position is assumed to be GPS

per RINEX 2 docs:
```
        snn                  s:    satellite system identifier
                                   G or blank : GPS
                                   R          : GLONASS
                                   T          : Transit
                            nn:    PRN (GPS), almanac number (GLONASS)
                                   or two-digit Transit satellite number

        Note: G is mandatory in mixed GPS/GLONASS files

                                   (blank default modified in April 1997)
```
Currently obs2 returns no data on files with blank SSI in SV SNN format because there are no SV's with SSI matching the indicated System ('G'). This change addresses this by checking for spaces when the SV list is generated, and replacing them with the assumed SSI indicator ('G'), aligning with any downstream comparisons to SSI.