### PR TITLE
Added sp3-a support for NGA compatibility

### DIFF
--- a/src/georinex/rio.py
+++ b/src/georinex/rio.py
@@ -129,6 +129,8 @@ def rinexinfo(f: T.TextIO | Path) -> dict[str, T.Any]:
             return {"version": "c", "rinextype": "sp3"}
         elif line.startswith("#d"):
             return {"version": "d", "rinextype": "sp3"}
+        elif line.startswith("#a"):
+            return {"version": "a", "rinextype": "sp3"}
 
         version = rinex_version(line)[0]
         file_type = line[20]
@@ -190,7 +192,7 @@ def rinex_version(s: str) -> tuple[float | str, bool]:
 
     # %% .sp3 file
     if s[0] == "#":
-        supported_versions = ["c", "d"]
+        supported_versions = ["a","c", "d"]
         if s[1] not in supported_versions:
             raise ValueError(
                 f"SP3 versions of SP3 files currently handled: {','.join(supported_versions)}"

--- a/src/georinex/sp3.py
+++ b/src/georinex/sp3.py
@@ -157,5 +157,12 @@ def get_sv(ln: str, Nsv: int) -> list[str]:
     i0 = 9
     svs = []
     for i in range(min(Nsv, 17)):
-        svs.append(ln[i0 + i * 3 : (i0 + 3) + i * 3])
+        sv=ln[i0 + i * 3 : (i0 + 3) + i * 3]
+        #this is for sp3-a only, because it doesn't have system identification
+        if sv[0]==' ':
+            sv=sv.replace(' ','0')
+            sv=sv[1:3]
+        svs.append(sv)
+    
+
     return svs

--- a/src/georinex/sp3.py
+++ b/src/georinex/sp3.py
@@ -142,7 +142,7 @@ def sp3dt(ln: str) -> datetime:
         hour=hour,
         minute=minute,
         second=second,
-        microsecond=int(ln[23:28]),
+        microsecond=int(ln[23:29]),
     )
 
     for t in dt:


### PR DESCRIPTION
NGA uses SP3-a to distribute GPS orbits with velocities. In order to use
that data with georinex a few modifications had to be made. There is no
system description for multi system files on sp3-a, so I removed that
from sv names.