### PR TITLE
Use ncompress for LZW decompression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
   numpy
   xarray>=0.11
   hatanaka
-  unlzw3
+  ncompress
 package_dir=
   =src
 

--- a/src/georinex/rio.py
+++ b/src/georinex/rio.py
@@ -11,12 +11,7 @@ import logging
 import xarray
 
 from hatanaka import crx2rnx
-
-try:
-    # The C-based unlzw lib is more efficient but also more difficult to install
-    from unlzw import unlzw
-except ImportError:
-    from unlzw3 import unlzw
+from ncompress import decompress as unlzw
 
 
 @contextmanager
@@ -68,8 +63,6 @@ def opener(fn: T.TextIO | Path, header: bool = False) -> T.Iterator[T.TextIO]:
                         )
                         yield f
         elif suffix == ".z":
-            if unlzw is None:
-                raise ImportError("pip install unlzw3")
             with fn.open("rb") as zu:
                 with io.StringIO(unlzw(zu.read()).decode("ascii")) as f:
                     yield f

--- a/src/georinex/tests/test_lzw.py
+++ b/src/georinex/tests/test_lzw.py
@@ -10,7 +10,7 @@ R = Path(__file__).parent / "data"
 
 
 def test_obs2_lzw():
-    pytest.importorskip("unlzw3")
+    pytest.importorskip("ncompress")
 
     fn = R / "ac660270.18o.Z"
 


### PR DESCRIPTION
Hi!
This PR replaces `unlzw3` and `unlzw` with `ncompress` for LZW decompression. Support for LZW compression and decompression was a bit lacking in Python, so I created a new [ncompress](https://github.com/valgur/ncompress) library to address that and add .Z output support to `hatanaka`. I thought you might find its decompression functionality useful as well.
Like `unlzw`, it is 40x faster than `unlzw3`, but the former currently has a [memory leak issue](https://github.com/ionelmc/python-unlzw/pull/3). It is based on the de-facto standard [(N)compress](https://github.com/vapier/ncompress) utility with only minimal changes to port its interface to C++ and should be as robust as it gets as a result.