### PR TITLE
Fix issue #95: 't0' attribute serialization problem

### DIFF
--- a/src/georinex/sp3.py
+++ b/src/georinex/sp3.py
@@ -120,7 +120,15 @@ def load_sp3(fn: Path, outfn: Path) -> xarray.Dataset:
     if outfn:
         outfn = Path(outfn).expanduser()
         enc = {k: ENC for k in ds.data_vars}
+        # Make a copy of the attributes to convert 't0' to a string for NetCDF
+        dat_for_netcdf = dat.copy()
+        # Convert the 't0' datetime to a string in the format YYYY-mm-dd HH:MM:SS
+        dat_for_netcdf["t0"] = dat_for_netcdf["t0"].strftime("%Y-%m-%d %H:%M:%S")
+        # Temporarily set the attributes to the copy with 't0' as a string
+        ds.attrs = dat_for_netcdf
         ds.to_netcdf(outfn, mode="w", encoding=enc)
+        # Reset the attributes to the original
+        ds.attrs = dat
 
     return ds
 

--- a/src/georinex/tests/test_conv.py
+++ b/src/georinex/tests/test_conv.py
@@ -71,6 +71,24 @@ def test_netcdf_write(tmp_path):
     assert obs.equals(wobs)
 
 
+def test_netcdf_write_sp3(tmp_path):
+    """
+    NetCDF4 wants suffix .nc -- arbitrary tempfile.NamedTemporaryFile names do NOT work!
+    """
+    pytest.importorskip("netCDF4")
+
+    fn = tmp_path / "rw.nc"
+    obs = gr.load(R / "example1.sp3a", out=fn)
+
+    wobs = xarray.load_dataset(fn)
+
+    assert obs.equals(wobs)
+
+    wobs.attrs['t0'] = datetime.strptime(wobs.attrs['t0'], '%Y-%m-%d %H:%M:%S')
+
+    assert obs.attrs == wobs.attrs
+
+
 def test_locs():
     pytest.importorskip("pymap3d")  # need to have this
     gg = pytest.importorskip("georinex.geo")


### PR DESCRIPTION
Converts the content of the 't0' attribute of SP3 files from datetime to, to allow it to be saved in NetCDF files. 
Also adds test for SP3 writing.

Before fix:
```python
test_conv.py::test_netcdf_write_sp3 FAILED                               [100%]
src/georinex/tests/test_conv.py:73 (test_netcdf_write_sp3)
tmp_path = PosixPath('/private/var/folders/kj/qs9_fmkj6y129023_fmlq4pw0000gn/T/pytest-of-linus/pytest-28/test_netcdf_write_sp30')

    def test_netcdf_write_sp3(tmp_path):
        """
        NetCDF4 wants suffix .nc -- arbitrary tempfile.NamedTemporaryFile names do NOT work!
        """
        pytest.importorskip("netCDF4")
    
        fn = tmp_path / "rw.nc"
>       obs = gr.load(R / "example1.sp3a", out=fn)

test_conv.py:81: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../venv/lib/python3.9/site-packages/georinex/base.py:83: in load
    return load_sp3(rinexfn, outfn)
../../../venv/lib/python3.9/site-packages/georinex/sp3.py:119: in load_sp3
    ds.to_netcdf(outfn, mode="w", encoding=enc)
../../../venv/lib/python3.9/site-packages/xarray/core/dataset.py:1912: in to_netcdf
    return to_netcdf(  # type: ignore  # mypy cannot resolve the overloads:(
../../../venv/lib/python3.9/site-packages/xarray/backends/api.py:1185: in to_netcdf
    _validate_attrs(dataset, invalid_netcdf=invalid_netcdf and engine == "h5netcdf")
../../../venv/lib/python3.9/site-packages/xarray/backends/api.py:203: in _validate_attrs
    check_attr(k, v, valid_types)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

name = 't0', value = datetime.datetime(1994, 12, 17, 0, 0)
valid_types = (<class 'str'>, <class 'numbers.Number'>, <class 'numpy.ndarray'>, <class 'numpy.number'>, <class 'list'>, <class 'tuple'>)

    def check_attr(name, value, valid_types):
        if isinstance(name, str):
            if not name:
                raise ValueError(
                    f"Invalid name for attr {name!r}: string must be "
                    "length 1 or greater for serialization to "
                    "netCDF files"
                )
        else:
            raise TypeError(
                f"Invalid name for attr: {name!r} must be a string for "
                "serialization to netCDF files"
            )
    
        if not isinstance(value, valid_types):
>           raise TypeError(
                f"Invalid value for attr {name!r}: {value!r}. For serialization to "
                "netCDF files, its value must be of one of the following types: "
                f"{', '.join([vtype.__name__ for vtype in valid_types])}"
            )
E           TypeError: Invalid value for attr 't0': datetime.datetime(1994, 12, 17, 0, 0). For serialization to netCDF files, its value must be of one of the following types: str, Number, ndarray, number, list, tuple

../../../venv/lib/python3.9/site-packages/xarray/backends/api.py:195: TypeError
```

After fix:
```shell
test_conv.py::test_netcdf_write_sp3 PASSED                               [100%]
```