### PR TITLE
treat blank observations as 0.0

### DIFF
--- a/src/georinex/nav3.py
+++ b/src/georinex/nav3.py
@@ -100,7 +100,7 @@ def rinexnav3(fn: T.TextIO | Path, use: set[str] = None, tlim: tuple[datetime, d
             for j, i in enumerate(svi):
                 try:
                     darr[j, compact_index] = [
-                        float(raws[i][LF * k : LF * (k + 1)]) for k in range(len(compact_index))
+                        float(raws[i][LF * k : LF * (k + 1)] or 0) for k in range(len(compact_index))
                     ]
                 except ValueError:
                     logging.info(f"malformed line for {sv}")


### PR DESCRIPTION
This pull request interprets blanks in RINEX 3 as 0.0. According to the [RINEX 3.04 specification](http://acc.igs.org/misc/rinex304.pdf) page A13 "Missing observations are written as 0.0 or blanks". Previously, blank observations caused a ValueError, were interpreted as a ["malformed line" and then discarded](https://github.com/geospace-code/georinex/blob/main/src/georinex/nav3.py#L106).

The following snippet downloads a RINEX 3 file and reproduces the error.
```
wget --ftp-user anonymous ftps://gdc.cddis.eosdis.nasa.gov/gnss/data/daily/2020/brdc/BRDC00IGS_R_20201360000_01D_MN.rnx.gz
gunzip BRDC00IGS_R_20201360000_01D_MN.rnx.gz
python -c "import georinex; georinex.load('BRDC00IGS_R_20201360000_01D_MN.rnx', use='E', verbose=True)"
```
Previous to this pull request there are many logging messages of `INFO:root:malformed line for E25` for example. With the new changes, no errors are logged.

All selftests are passing.